### PR TITLE
Launch overlay with VSCode tasks API

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,13 @@
   "contributes": {
     "commands": [
       {
-        "command": "cheerleader.helloWorld",
-        "title": "Hello World",
+        "command": "cheerleader.launchOverlay",
+        "title": "Launch Interactive Cheerleader",
+        "category": "Cheerleader"
+      },
+      {
+        "command": "cheerleader.killOverlay",
+        "title": "Dismiss Interactive Cheerleader",
         "category": "Cheerleader"
       },
       {


### PR DESCRIPTION
Use VSCode's [Tasks API](https://code.visualstudio.com/docs/debugtest/tasks) to launch the anime overlay app instead of `child_process.spawn()`.